### PR TITLE
Fix for negative tax on free shipping coupon

### DIFF
--- a/src/DIBS Payment Window/includes/modules/payment/dibs_api/pw/dibs_pw_helpers.php
+++ b/src/DIBS Payment Window/includes/modules/payment/dibs_api/pw/dibs_pw_helpers.php
@@ -207,7 +207,7 @@ class dibs_pw_helpers extends dibs_pw_helpers_cms implements dibs_pw_helpers_int
         $sRate = (isset($mOrderInfo->info['currency_value'])) ?
                  ($mOrderInfo->info['shipping_cost'] * $mOrderInfo->info['currency_value']) :
                   $mOrderInfo->info['shipping_cost'];
-        if(defined(DISPLAY_PRICE_WITH_TAX) && DISPLAY_PRICE_WITH_TAX == "true") $sRate -= $sTax;
+        if((defined(DISPLAY_PRICE_WITH_TAX) && DISPLAY_PRICE_WITH_TAX == "true") && $sRate > $sTax) $sRate -= $sTax;
         
         return (object)array(
                 'id'         => "shipping",


### PR DESCRIPTION
Today when a coupon with free shipping is used, the shipping rate is sent to DPW as a negative value because of the tax being subtracted from zero.

With this fix the tax is only subtracted from shipping rate if it's grater than the tax value.

Note! It might need to be added more checking and calculation to avoid any other issues, but I really don't see how that would be any real issues - unless the carts config is very wrong. Normally it should be enough to do the subtraction of tax if shipping rate is greater than zero, I just used greater than tax value to ensure it's not getting negative...